### PR TITLE
doc: Add Chan et al. (2024) to bibliography

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Cassandra L. Jacobs and Morgan Grobol. 2025. <a href="https://aclanthology.org/2
 Enzo Doyen and Amalia Todirascu. 2025. <a href="https://arxiv.org/abs/2505.23630"><u>GeNRe: A French Gender-Neutral Rewriting System Using Collective Nouns.</u></a> _Computing Research Repository_, arXiv:2505.23630. Forthcoming in _Findings of the Association for Computational Linguistics 2025_.
 
 ## LLMs
+Fai Leui Chan, Duke Nguyen, and Aditya Joshi. 2024. <a href="https://aclanthology.org/2024.alta-1.16"><u>"Is Hate Lost in Translation?": Evaluation of Multilingual LGBTQIA+ Hate Speech Detection.</u></a> In _Proceedings of The 22nd Annual Workshop of the Australasian Language Technology Association_, pages 146-152, Canberra, Australia. Association for Computational Linguistics.
+
 Emily Sheng, Kai-Wei Chang, Premkumar Natarajan, and Nanyun Peng. 2019. <a href="https://aclanthology.org/D19-1339"><u>The Woman Worked as a Babysitter: On Biases in Language Generation.</u></a> In _Proceedings of the 2019 Conference on Empirical Methods in Natural Language Processing and the 9th International Joint Conference on Natural Language Processing (EMNLP-IJCNLP)_, pages 3407–3412, Hong Kong, China. Association for Computational Linguistics.
 
 Debora Nozza, Federico Bianchi, Anne Lauscher, and Dirk Hovy. 2022. <a href="https://aclanthology.org/2022.ltedi-1.4/"><u>Measuring Harmful Sentence Completion in Language Models for LGBTQIA+ Individuals.</u></a> In _Proceedings of the Second Workshop on Language Technology for Equality, Diversity and Inclusion_, pages 26–34, Dublin, Ireland. Association for Computational Linguistics.
@@ -190,6 +192,8 @@ Andreas Waldis, Joel Birrer, Anne Lauscher, and Iryna Gurevych. 2024. <a href="h
 Eddie Ungless, Bjorn Ross, and Anne Lauscher. 2023. <a href="https://aclanthology.org/2023.findings-acl.502/"><u>Stereotypes and Smut: The (Mis)representation of Non-cisgender Identities by Text-to-Image Models.</u></a> In _Findings of the Association for Computational Linguistics: ACL 2023_, pages 7919–7942, Toronto, Canada. Association for Computational Linguistics.
 
 ## Toxicity and Hate/Hope Speech
+Fai Leui Chan, Duke Nguyen, and Aditya Joshi. 2024. <a href="https://aclanthology.org/2024.alta-1.16"><u>"Is Hate Lost in Translation?": Evaluation of Multilingual LGBTQIA+ Hate Speech Detection.</u></a> In _Proceedings of The 22nd Annual Workshop of the Australasian Language Technology Association_, pages 146-152, Canberra, Australia. Association for Computational Linguistics.
+
 Zueva, Nadezhda, Madina Kabirova, and Pavel Kalaidin. 2020. <a href="https://aclanthology.org/2020.alw-1.8/"><u>Reducing Unintended Identity Bias in Russian Hate Speech Detection.</u></a> In _Proceedings of the Fourth Workshop on Online Abuse and Harms_, pages 65–69, Online. Association for Computational Linguistics.
 
 Jamell Dacon, Harry Shomer, Shaylynn Crum-Dacon, and Jiliang Tang. 2022. <a href="https://arxiv.org/abs/2207.10032"><u>Detecting Harmful Online Conversational Content towards LGBTQIA+ Individuals.</u></a> _Computing Research Repository_, arXiv:2207.10032. Presented at the Queer in AI Workshop at NAACL 2022.
@@ -237,6 +241,8 @@ Marcos Barbosa, Carlos Arcila, and Patricia Sánchez-Holgado. 2025. <a href="htt
 Shared tasks papers: [LTEDI22](#ltedi22), [LTEDI23](#ltedi23), [LTEDI24](#ltedi24), [LTEDI 2025](#ltedi25), [HOMO-MEX23](#homomex23), [HOMO-MEX24](#homomex24), [HOPE23](#hope23), [HOPE24](#hope24), [HODI23](#hodi23)
 
 ## Translation
+Fai Leui Chan, Duke Nguyen, and Aditya Joshi. 2024. <a href="https://aclanthology.org/2024.alta-1.16"><u>"Is Hate Lost in Translation?": Evaluation of Multilingual LGBTQIA+ Hate Speech Detection.</u></a> In _Proceedings of The 22nd Annual Workshop of the Australasian Language Technology Association_, pages 146-152, Canberra, Australia. Association for Computational Linguistics.
+
 Angela Balducci Paolucci, Manuel Lardelli, and Dagmar Gromann. 2023. <a href="https://aclanthology.org/2023.gitt-1.2/"><u>Gender-Fair Language in Translation: A Case Study.</u></a> In _Proceedings of the First Workshop on Gender-Inclusive Translation Technologies_, pages 13–23, Tampere, Finland. European Association for Machine Translation.
 
 Anne Lauscher, Debora Nozza, Ehm Miltersen, Archie Crowley, and Dirk Hovy. 2023. <a href="https://aclanthology.org/2023.acl-long.23/"><u> What about “em”? How Commercial Machine Translation Fails to Handle (Neo-)Pronouns.</u></a> In _Proceedings of the 61st Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)_, pages 377–392, Toronto, Canada. Association for Computational Linguistics.

--- a/refs.bib
+++ b/refs.bib
@@ -1268,6 +1268,24 @@ Text to Image
 
 Toxicity and Hate Speech
 
+@inproceedings{chan-etal-2024-hate,
+    title = "``Is Hate Lost in Translation?'': Evaluation of Multilingual {LGBTQIA}+ Hate Speech Detection",
+    author = "Chan, Fai Leui  and
+      Nguyen, Duke  and
+      Joshi, Aditya",
+    editor = "Baldwin, Tim  and
+      Rodr{\'i}guez M{\'e}ndez, Sergio Jos{\'e}  and
+      Kuo, Nicholas",
+    booktitle = "Proceedings of the 22nd Annual Workshop of the Australasian Language Technology Association",
+    month = dec,
+    year = "2024",
+    address = "Canberra, Australia",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2024.alta-1.11/",
+    pages = "146--152",
+    abstract = "This paper explores the challenges of detecting LGBTQIA+ hate speech of large language models across multiple languages, including English, Italian, Chinese and (code-mixed) English-Tamil, examining the impact of machine translation and whether the nuances of hate speech are preserved across translation. We examine the hate speech detection ability of zero-shot and fine-tuned GPT. Our findings indicate that: (1) English has the highest performance and the code-mixing scenario of English-Tamil being the lowest, (2) fine-tuning improves performance consistently across languages whilst translation yields mixed results. Through simple experimentation with original text and machine-translated text for hate speech detection along with a qualitative error analysis, this paper sheds light on the socio-cultural nuances and complexities of languages that may not be captured by automatic translation."
+}
+
 @inproceedings{zueva-etal-2020-reducing,
     title = "Reducing Unintended Identity Bias in {R}ussian Hate Speech Detection",
     author = "Zueva, Nadezhda  and


### PR DESCRIPTION
This pull request adds the following paper to the Queer NLP bibliography:

  * **Title:** "Is Hate Lost in Translation?": Evaluation of Multilingual LGBTQIA+ Hate Speech Detection
  * **Authors:** Fai Leui Chan, Duke Nguyen, and Aditya Joshi
  * **Conference:** Proceedings of The 22nd Annual Workshop of the Australasian Language Technology Association (ALTA 2024)
  * **Link:** [https://aclanthology.org/2024.alta-1.11/](https://aclanthology.org/2024.alta-1.11/)

The paper has been added to the following sections in `README.md`:

  * Toxicity and Hate/Hope Speech
  * LLMs
  * Translation

The BibTeX entry has also been added to `refs.bib`.

This contribution helps to keep the bibliography current with the latest research in Queer NLP.