### PR TITLE
Add FAccT and ACL 2025 papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ Rachel Rudinger, Jason Naradowsky, Brian Leonard, and Benjamin Van Durme. 2018. 
 
 Hannah Devinney, Jenny Björklund, and Henrik Björklund. 2020. <a href="https://aclanthology.org/2020.gebnlp-1.8/"><u>Semi-supervised topic modeling for gender bias discovery in English and Swedish.</u></a> In _Proceedings of the Second Workshop on Gender Bias in Natural Language Processing_, pages 79–92, Barcelona, Spain (Online). Association for Computational Linguistics.
 
-Saga Hansson, Konstantinos Mavromatakis, Yvonne Adesam, Gerlof Bouma, and Dana Dannélls. 2021. <a href="https://aclanthology.org/2021.nodalida-main.52/"><u>The Swedish Winogender Dataset.</u></a> In _Proceedings of the 23rd Nordic Conference on Computational Linguistics (NoDaLiDa)_, pages 452–459, Reykjavik, Iceland (Online). Linköping University Electronic Press.
-
 Lucy Havens, Melissa Terras, Benjamin Bach, and Beatrice Alex. 2022. <a href="https://aclanthology.org/2022.gebnlp-1.4/"><u>Uncertainty and inclusivity in gender bias annotation: An annotation taxonomy and annotated datasets of British English text.</u></a> In _Proceedings of the 4th Workshop on Gender Bias in Natural Language Processing (GeBNLP)_, pages 30–57, Seattle, WA, USA. Association for Computational Linguistics.
 
 Stephanie Brandl, Ruixiang Cui, and Anders Søgaard. 2022. <a href="https://aclanthology.org/2022.naacl-main.265/"><u>How Conservative are Language Models? Adapting to the Introduction of Gender-Neutral Pronouns.</u></a> In _Proceedings of the 2022 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies_, pages 3624–3630, Seattle, WA, USA. Association for Computational Linguistics.
@@ -96,9 +94,9 @@ Kunsheng Tang, Wenbo Zhou, Jie Zhang, Aishan Liu, Gelei Deng, Shuai Li, Peigui Q
 
 Cassandra L. Jacobs and Morgan Grobol. 2025. <a href="https://aclanthology.org/2025.queerinai-main.5/"><u>A Bayesian account of pronoun and neopronoun acquisition.</u></a> In _Proceedings of the Queer in AI Workshop at NAACL 2025_, pages 35–40, Albuquerque, NM, USA (Hybrid). Association for Computational Linguistics.
 
-Enzo Doyen and Amalia Todirascu. 2025. <a href="https://arxiv.org/abs/2505.23630"><u>GeNRe: A French Gender-Neutral Rewriting System Using Collective Nouns.</u></a> _Computing Research Repository_, arXiv:2505.23630. Forthcoming in _Findings of the Association for Computational Linguistics 2025_.
-
 Franziska Sofia Hafner, Ana Valdivia, and Luc Rocher. 2025. <a href="https://dl.acm.org/doi/10.1145/3715275.3732112"><u>Gender Trouble in Language Models: An Empirical Audit Guided by Gender Performativity Theory.</u></a> In _Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency (FAccT '25)_, pages 1677–1695, Athens, Greece. Association for Computing Machinery.
+
+Enzo Doyen and Amalia Todirascu. 2025. <a href="https://aclanthology.org/2025.findings-acl.411/"><u>GeNRe: A French Gender-Neutral Rewriting System Using Collective Nouns.</u></a> In _Findings of the Association for Computational Linguistics: ACL 2025_, pages 7889–7909, Vienna, Austria. Association for Computational Linguistics.
 
 Elisa Forcada Rodríguez, Olatz Perez-de-Vinaspre, Jon Ander Campos, Dietrich Klakow, and Vagrant Gautam. 2025. <a href="https://aclanthology.org/2025.gebnlp-1.18/"><u>Colombian Waitresses y Jueces canadienses: Gender and Country Biases in Occupation Recommendations from LLMs.</u></a> In _Proceedings of the 6th Workshop on Gender Bias in Natural Language Processing (GeBNLP)_, pages 182–194, Vienna, Austria. Association for Computational Linguistics.
 
@@ -142,6 +140,8 @@ Hannah Devinney, Jenny Björklund, and Henrik Björklund. 2024. <a href="https:/
 Urban Knupleš, Agnieszka Falenska, and Filip Miletić. 2024. <a href="https://aclanthology.org/2024.findings-emnlp.680/"><u>Gender Identity in Pretrained Language Models: An Inclusive Approach to Data Creation and Probing.</u></a> In _Findings of the Association for Computational Linguistics: EMNLP 2024_, pages 11612–11631, Miami, FL, USA. Association for Computational Linguistics.
 
 Kunsheng Tang, Wenbo Zhou, Jie Zhang, Aishan Liu, Gelei Deng, Shuai Li, Peigui Qi, Weiming Zhang, Tianwei Zhang, and NengHai Yu. 2024. <a href="https://dl.acm.org/doi/abs/10.1145/3658644.3670284"><u>GenderCARE: A Comprehensive Framework for Assessing and Reducing Gender Bias in Large Language Models.</u></a> In _Proceedings of the 2024 on ACM SIGSAC Conference on Computer and Communications Security (CCS '24)_, pages 1196–1210, Salt Lake City, UT, USA. Association for Computing Machinery.
+
+Fai Leui Chan, Duke Nguyen, and Aditya Joshi. 2024. <a href="https://aclanthology.org/2024.alta-1.11/"><u>”Is Hate Lost in Translation?”: Evaluation of Multilingual LGBTQIA+ Hate Speech Detection.</u></a> In _Proceedings of the 22nd Annual Workshop of the Australasian Language Technology Association_, pages 146–152, Canberra, Australia. Association for Computational Linguistics.
 
 Joshua Tint. 2025. <a href="https://aclanthology.org/2025.queerinai-main.2/"><u>Guardrails, not Guidance: Understanding Responses to LGBTQ+ Language in Large Language Models.</u></a> In _Proceedings of the Queer in AI Workshop at NAACL 2025_, pages 6–16, Albuquerque, NM, USA (Hybrid). Association for Computational Linguistics.
 
@@ -240,7 +240,7 @@ Michael Wiegand and Josef Ruppenhofer. 2024. <a href="https://aclanthology.org/2
 
 Fai Leui Chan, Duke Nguyen, and Aditya Joshi. 2024. <a href="https://aclanthology.org/2024.alta-1.11/"><u>”Is Hate Lost in Translation?”: Evaluation of Multilingual LGBTQIA+ Hate Speech Detection.</u></a> In _Proceedings of the 22nd Annual Workshop of the Australasian Language Technology Association_, pages 146–152, Canberra, Australia. Association for Computational Linguistics.
 
-Lia Draetta, Chiara Ferrando, Marco Cuccarini, Liam James, and Viviana Patti. 2024. <a href="https://aclanthology.org/2024.clicit-1.40/"><u>ReCLAIM Project: Exploring Italian Slurs Reappropriation with Large Language Models.</u></a> In _Proceedings of the 10th Italian Conference on Computational Linguistics (CLiC-it 2024)_, pages 335–342, Pisa, Italy. CEUR Workshop Proceedings.
+Lia Draetta, Chiara Ferrando, Marco Cuccarini, Liam James, and Viviana Patti. 2024. <a href="https://aclanthology.org/2024.clicit-1.40/"><u>ReCLAIM Project: Exploring Italian Slurs Reappropriation with Large Language Models.</u></a> In _Proceedings of the 10th Italian Conference on Computational Linguistics (CLiC-it 2024)_, pages 335–342, Pisa, Italy. CEUR-WS.org.
 
 Juan Manuel Pérez, Paula Miguel, and Viviana Cotik. 2025. <a href="https://aclanthology.org/2025.findings-naacl.400/"><u>Exploring Large Language Models for Hate Speech Detection in Rioplatense Spanish.</u></a> In _Findings of the Association for Computational Linguistics: NAACL 2025_, pages 7174–7187, Albuquerque, NM, USA. Association for Computational Linguistics.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ Bastian Bunzeck and Sina Zarrieß. 2024. <a href="https://aclanthology.org/2024.
 
 Kunsheng Tang, Wenbo Zhou, Jie Zhang, Aishan Liu, Gelei Deng, Shuai Li, Peigui Qi, Weiming Zhang, Tianwei Zhang, and NengHai Yu. 2024. <a href="https://dl.acm.org/doi/abs/10.1145/3658644.3670284"><u>GenderCARE: A Comprehensive Framework for Assessing and Reducing Gender Bias in Large Language Models.</u></a> In _Proceedings of the 2024 on ACM SIGSAC Conference on Computer and Communications Security (CCS '24)_, pages 1196–1210, Salt Lake City, UT, USA. Association for Computing Machinery.
 
-Arjun Subramonian, Vagrant Gautam, Preethi Seshadri, Dietrich Klakow, Kai-Wei Chang and Yizhou Sun. 2025. <a href="https://arxiv.org/abs/2504.17075#"><u>Agree to Disagree? A Meta-Evaluation of LLM Misgendering</u></a> _Computing Research Repository_, arXiv:2504.17075. Work in progress.
+Arjun Subramonian, Vagrant Gautam, Preethi Seshadri, Dietrich Klakow, Kai-Wei Chang and Yizhou Sun. 2025. <a href="https://arxiv.org/abs/2504.17075#"><u>Agree to Disagree? A Meta-Evaluation of LLM Misgendering.</u></a> _Computing Research Repository_, arXiv:2504.17075. Work in progress.
+
+Greta Damo, Alessandra Teresa Cignarella, Tommaso Caselli, Viviana Patti, and Debora Nozza. 2025. <a href="https://aclanthology.org/2025.woah-1.11/"><u>HODIAT: A Dataset for Detecting Homotransphobic Hate Speech in Italian with Aggressiveness and Target Annotation.</u></a> In _Proceedings of the The 9th Workshop on Online Abuse and Harms (WOAH)_, pages 124–135, Vienna, Austria. Association for Computational Linguistics.
 
 ## Gender Bias Including Nonbinary Genders
 Rachel Rudinger, Jason Naradowsky, Brian Leonard, and Benjamin Van Durme. 2018. <a href="https://aclanthology.org/N18-2002/"><u>Gender Bias in Coreference Resolution.</u></a> In _Proceedings of the 2018 Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies, Volume 2 (Short Papers)_, pages 8–14, New Orleans, LA, USA. Association for Computational Linguistics.
@@ -95,6 +97,16 @@ Kunsheng Tang, Wenbo Zhou, Jie Zhang, Aishan Liu, Gelei Deng, Shuai Li, Peigui Q
 Cassandra L. Jacobs and Morgan Grobol. 2025. <a href="https://aclanthology.org/2025.queerinai-main.5/"><u>A Bayesian account of pronoun and neopronoun acquisition.</u></a> In _Proceedings of the Queer in AI Workshop at NAACL 2025_, pages 35–40, Albuquerque, NM, USA (Hybrid). Association for Computational Linguistics.
 
 Enzo Doyen and Amalia Todirascu. 2025. <a href="https://arxiv.org/abs/2505.23630"><u>GeNRe: A French Gender-Neutral Rewriting System Using Collective Nouns.</u></a> _Computing Research Repository_, arXiv:2505.23630. Forthcoming in _Findings of the Association for Computational Linguistics 2025_.
+
+Franziska Sofia Hafner, Ana Valdivia, and Luc Rocher. 2025. <a href="https://dl.acm.org/doi/10.1145/3715275.3732112"><u>Gender Trouble in Language Models: An Empirical Audit Guided by Gender Performativity Theory.</u></a> In _Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency (FAccT '25)_, pages 1677–1695, Athens, Greece. Association for Computing Machinery.
+
+Elisa Forcada Rodríguez, Olatz Perez-de-Vinaspre, Jon Ander Campos, Dietrich Klakow, and Vagrant Gautam. 2025. <a href="https://aclanthology.org/2025.gebnlp-1.18/"><u>Colombian Waitresses y Jueces canadienses: Gender and Country Biases in Occupation Recommendations from LLMs.</u></a> In _Proceedings of the 6th Workshop on Gender Bias in Natural Language Processing (GeBNLP)_, pages 182–194, Vienna, Austria. Association for Computational Linguistics.
+
+Janiça Hackenbuchner, Joke Daems, and Eleni Gkovedarou. 2025. <a href="https://aclanthology.org/2025.gebnlp-1.27/"><u>GENDEROUS: Machine Translation and Cross-Linguistic Evaluation of a Gender-Ambiguous Dataset.</u></a> In _Proceedings of the 6th Workshop on Gender Bias in Natural Language Processing (GeBNLP)_, pages 302–319, Vienna, Austria. Association for Computational Linguistics.
+
+Paolo Mainardi, Federico Garcea, and Alberto Barrón-Cedeño. 2025. <a href="https://aclanthology.org/2025.gebnlp-1.28/"><u>Fine-Tuning vs Prompting Techniques for Gender-Fair Rewriting of Machine Translations.</u></a> In _Proceedings of the 6th Workshop on Gender Bias in Natural Language Processing (GeBNLP)_, pages 320–337, Vienna, Austria. Association for Computational Linguistics.
+
+Marion Bartl, Thomas Brendan Murphy, and Susan Leavy. 2025. <a href="https://aclanthology.org/2025.gebnlp-1.38/"><u>Adapting Psycholinguistic Research for LLMs: Gender-inclusive Language in a Coreference Context.</u></a> In _Proceedings of the 6th Workshop on Gender Bias in Natural Language Processing (GeBNLP)_, pages 451–467, Vienna, Austria. Association for Computational Linguistics.
 
 ## LLMs
 Emily Sheng, Kai-Wei Chang, Premkumar Natarajan, and Nanyun Peng. 2019. <a href="https://aclanthology.org/D19-1339"><u>The Woman Worked as a Babysitter: On Biases in Language Generation.</u></a> In _Proceedings of the 2019 Conference on Empirical Methods in Natural Language Processing and the 9th International Joint Conference on Natural Language Processing (EMNLP-IJCNLP)_, pages 3407–3412, Hong Kong, China. Association for Computational Linguistics.
@@ -131,8 +143,6 @@ Urban Knupleš, Agnieszka Falenska, and Filip Miletić. 2024. <a href="https://a
 
 Kunsheng Tang, Wenbo Zhou, Jie Zhang, Aishan Liu, Gelei Deng, Shuai Li, Peigui Qi, Weiming Zhang, Tianwei Zhang, and NengHai Yu. 2024. <a href="https://dl.acm.org/doi/abs/10.1145/3658644.3670284"><u>GenderCARE: A Comprehensive Framework for Assessing and Reducing Gender Bias in Large Language Models.</u></a> In _Proceedings of the 2024 on ACM SIGSAC Conference on Computer and Communications Security (CCS '24)_, pages 1196–1210, Salt Lake City, UT, USA. Association for Computing Machinery.
 
-Anaelia Ovalle, Krunoslav Lehman Pavasovic, Louis Martin, Luke Zettlemoyer, Eric Michael Smith, Adina Williams, and Levent Sagun. 2024. <a href="https://arxiv.org/abs/2411.03700"><u>The Root Shapes the Fruit: On the Persistence of Gender-Exclusive Harms in Aligned Language Models.</u></a> _Computing Research Repository_, arXiv:2411.03700. Presented at the Queer in AI Workshop at NeurIPS 2024.
-
 Joshua Tint. 2025. <a href="https://aclanthology.org/2025.queerinai-main.2/"><u>Guardrails, not Guidance: Understanding Responses to LGBTQ+ Language in Large Language Models.</u></a> In _Proceedings of the Queer in AI Workshop at NAACL 2025_, pages 6–16, Albuquerque, NM, USA (Hybrid). Association for Computational Linguistics.
 
 Alexandria Leto, Juan Vásquez, Alexis Palmer, and Maria Leonor Pacheco. 2025. <a href="https://aclanthology.org/2025.queerinai-main.3/"><u>Dehumanization of LGBTQ+ Groups in Sexual Interactions with ChatGPT.</u></a> In _Proceedings of the Queer in AI Workshop at NAACL 2025_, pages 17–25, Albuquerque, NM, USA (Hybrid). Association for Computational Linguistics.
@@ -142,6 +152,8 @@ Quoc-Toan Nguyen, Josh Nguyen, Tuan Pham, and William John Teahan. 2025. <a href
 Ruby Ostrow and Adam Lopez. 2025. <a href="https://arxiv.org/abs/2501.05926"><u>LLMs Reproduce Stereotypes of Sexual and Gender Minorities.</u></a> _Computing Research Repository_, arXiv:2501.05926. Under review.
 
 Jeffrey Basoah, Daniel Chechelnitsky, Tao Long, Katharina Reinecke, Chrysoula Zerva, Kaitlyn Zhou, Mark Díaz, and Maarten Sap. 2025. <a href="https://dl.acm.org/doi/10.1145/3715275.3732045"><u>Not Like Us, Hunty: Measuring Perceptions and Behavioral Effects of Minoritized Anthropomorphic Cues in LLMs.</u></a> In _Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency (FAccT '25)_, pages 710–745, Athens, Greece. Association for Computing Machinery.
+
+Anaelia Ovalle, Krunoslav Lehman Pavasovic, Louis Martin, Luke Zettlemoyer, Eric Michael Smith, Kai-Wei Chang, Adina Williams, and Levent Sagun. 2025. <a href="https://dl.acm.org/doi/10.1145/3715275.3732196"><u>The Root Shapes the Fruit: On the Persistence of Gender-Exclusive Harms in Aligned Language Models.</u></a> In _Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency (FAccT '25)_, pages 3094–3105, Athens, Greece. Association for Computing Machinery.
 
 ## Media Analysis using NLP 
 Amanda Hicks, Michael Rutherford, Christiane Fellbaum, and Jiang Bian. 2016. <a href="https://aclanthology.org/2016.gwc-1.19"><u>An analysis of wordnet’s coverage of gender identity using twitter and the national transgender discrimination survey.</u></a> In _Proceedings of the 8th Global WordNet Conference (GWC)_, pages 123–130, Bucharest, Romania. Global Wordnet Association.
@@ -226,6 +238,8 @@ Rebecca Dorn, Lee Kezar, Fred Morstatter, and Kristina Lerman. 2024. <a href="ht
 
 Michael Wiegand and Josef Ruppenhofer. 2024. <a href="https://aclanthology.org/2024.emnlp-main.132/"><u>Oddballs and Misfits: Detecting Implicit Abuse in Which Identity Groups are Depicted as Deviating from the Norm.</u></a> In _Proceedings of the 2024 Conference on Empirical Methods in Natural Language Processing_, pages 2200–2218, Miami, FL, USA. Association for Computational Linguistics.
 
+Fai Leui Chan, Duke Nguyen, and Aditya Joshi. 2024. <a href="https://aclanthology.org/2024.alta-1.11/"><u>”Is Hate Lost in Translation?”: Evaluation of Multilingual LGBTQIA+ Hate Speech Detection.</u></a> In _Proceedings of the 22nd Annual Workshop of the Australasian Language Technology Association_, pages 146–152, Canberra, Australia. Association for Computational Linguistics.
+
 Lia Draetta, Chiara Ferrando, Marco Cuccarini, Liam James, and Viviana Patti. 2024. <a href="https://aclanthology.org/2024.clicit-1.40/"><u>ReCLAIM Project: Exploring Italian Slurs Reappropriation with Large Language Models.</u></a> In _Proceedings of the 10th Italian Conference on Computational Linguistics (CLiC-it 2024)_, pages 335–342, Pisa, Italy. CEUR Workshop Proceedings.
 
 Juan Manuel Pérez, Paula Miguel, and Viviana Cotik. 2025. <a href="https://aclanthology.org/2025.findings-naacl.400/"><u>Exploring Large Language Models for Hate Speech Detection in Rioplatense Spanish.</u></a> In _Findings of the Association for Computational Linguistics: NAACL 2025_, pages 7174–7187, Albuquerque, NM, USA. Association for Computational Linguistics.
@@ -233,6 +247,10 @@ Juan Manuel Pérez, Paula Miguel, and Viviana Cotik. 2025. <a href="https://acla
 Quoc-Toan Nguyen, Josh Nguyen, Tuan Pham, and William John Teahan. 2025. <a href="https://aclanthology.org/2025.queerinai-main.4/"><u>Leveraging Large Language Models in Detecting Anti-LGBTQIA+ User-generated Texts.</u></a> In _Proceedings of the Queer in AI Workshop at NAACL 2025_, pages 26–34, Albuquerque, NM, USA (Hybrid). Association for Computational Linguistics.
 
 Marcos Barbosa, Carlos Arcila, and Patricia Sánchez-Holgado. 2025. <a href="https://revistas.uned.es/index.php/empiria/article/view/45201"><u>LGTBfobia en redes sociales: Revisión sistemática de la detección y clasificación de discurso de odio a gran escala.</u></a> _EMPIRIA. Revista de Metodología de Ciencias Sociales_, 64:51–79.
+
+Francesca Lameiro, Lavinia Dunagan, Dallas Card, Eric Gilbert, and Oliver Haimson. 2025. <a href="https://dl.acm.org/doi/10.1145/3715275.3732095#fn3"><u>TIDEs: A Transgender and Nonbinary Community-Labeled Dataset and Model for Transphobia Identification in Digital Environments.</u></a> In _Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency (FAccT '25)_, pages 1411–1423, Athens, Greece. Association for Computing Machinery.
+
+Anna Talas and Alice Hutchings. 2025. <a href="https://aclanthology.org/2025.woah-1.12/"><u>Beyond the Binary: Analysing Transphobic Hate and Harassment Online.</u></a> In _Proceedings of the The 9th Workshop on Online Abuse and Harms (WOAH)_, pages 136–152, Vienna, Austria. Association for Computational Linguistics.
 
 Shared tasks papers: [LTEDI22](#ltedi22), [LTEDI23](#ltedi23), [LTEDI24](#ltedi24), [LTEDI 2025](#ltedi25), [HOMO-MEX23](#homomex23), [HOMO-MEX24](#homomex24), [HOPE23](#hope23), [HOPE24](#hope24), [HODI23](#hodi23)
 
@@ -254,6 +272,8 @@ Ian Stewart and Rada Mihalcea. 2024. <a href="https://aclanthology.org/2024.gebn
 Kevin Robinson, Sneha Kudugunta, Romina Stella, Sunipa Dev, and Jasmijn Bastings. 2024. <a href="https://aclanthology.org/2024.emnlp-main.238/"><u>MiTTenS: A Dataset for Evaluating Gender Mistranslation.</u></a> In _Proceedings of the 2024 Conference on Empirical Methods in Natural Language Processing_, pages 4115–4124, Miami, FL, USA. Association for Computational Linguistics.
 
 Steinunn Rut Friðriksdóttir. 2024. <a href="https://aclanthology.org/2024.wmt-1.26/"><u>The GenderQueer Test Suite.</u></a> In _Proceedings of the Ninth Conference on Machine Translation_, pages 327–340, Miami, FL, USA. Association for Computational Linguistics.
+
+Fai Leui Chan, Duke Nguyen, and Aditya Joshi. 2024. <a href="https://aclanthology.org/2024.alta-1.11/"><u>”Is Hate Lost in Translation?”: Evaluation of Multilingual LGBTQIA+ Hate Speech Detection.</u></a> In _Proceedings of the 22nd Annual Workshop of the Australasian Language Technology Association_, pages 146–152, Canberra, Australia. Association for Computational Linguistics.
 
 Fanny Jourdan, Yannick Chevalier, and Cécile Favre. 2025. <a href="https://dl.acm.org/doi/10.1145/3715275.3732013"><u>FairTranslate: an English-French Dataset for Gender Bias Evaluation in Machine Translation by Overcoming Gender Binarity.</u></a> In _Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency (FAccT '25)_, pages 150–166, Athens, Greece. Association for Computing Machinery.
 

--- a/refs.bib
+++ b/refs.bib
@@ -408,6 +408,28 @@ series = {AIES '23}
       url={https://arxiv.org/abs/2504.17075},
       note={Work in progress.}
 }
+@inproceedings{damo-etal-2025-hodiat,
+    title = "{HODIAT}: A Dataset for Detecting Homotransphobic Hate Speech in {I}talian with Aggressiveness and Target Annotation",
+    author = "Damo, Greta  and
+      Cignarella, Alessandra Teresa  and
+      Caselli, Tommaso  and
+      Patti, Viviana  and
+      Nozza, Debora",
+    editor = "Calabrese, Agostina  and
+      de Kock, Christine  and
+      Nozza, Debora  and
+      Plaza-del-Arco, Flor Miriam  and
+      Talat, Zeerak  and
+      Vargas, Francielle",
+    booktitle = "Proceedings of the The 9th Workshop on Online Abuse and Harms (WOAH)",
+    month = aug,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.woah-1.11/",
+    pages = "124--135",
+    ISBN = "979-8-89176-105-6",
+}
 
 Gender Bias Including Nonbinary Genders
 
@@ -605,6 +627,100 @@ Gender Bias Including Nonbinary Genders
       primaryClass={cs.CL},
       url={https://arxiv.org/abs/2505.23630}, 
       note={Forthcoming in ACL Findings 2025}
+}
+@inproceedings{10.1145/3715275.3732112,
+author = {Hafner, Franziska Sofia and Valdivia, Ana and Rocher, Luc},
+title = {Gender Trouble in Language Models: An Empirical Audit Guided by Gender Performativity Theory},
+year = {2025},
+month = jun,
+isbn = {9798400714825},
+publisher = {Association for Computing Machinery},
+address = {Athens, Greece},
+url = {https://doi.org/10.1145/3715275.3732112},
+doi = {10.1145/3715275.3732112},
+booktitle = {Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency},
+pages = {1677–1695},
+numpages = {19},
+location = {New York, NY, USA},
+series = {FAccT '25}
+}
+@inproceedings{rodriguez-etal-2025-colombian,
+    title = "Colombian Waitresses y Jueces canadienses: Gender and Country Biases in Occupation Recommendations from {LLM}s",
+    author = "Rodr{\'i}guez, Elisa Forcada  and
+      Perez-de-Vinaspre, Olatz  and
+      Campos, Jon Ander  and
+      Klakow, Dietrich  and
+      Gautam, Vagrant",
+    editor = "Fale{\'n}ska, Agnieszka  and
+      Basta, Christine  and
+      Costa-juss{\`a}, Marta  and
+      Sta{\'n}czak, Karolina  and
+      Nozza, Debora",
+    booktitle = "Proceedings of the 6th Workshop on Gender Bias in Natural Language Processing (GeBNLP)",
+    month = aug,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.gebnlp-1.18/",
+    pages = "182--194",
+    ISBN = "979-8-89176-277-0",
+}
+@inproceedings{hackenbuchner-etal-2025-genderous,
+    title = "{GENDEROUS}: Machine Translation and Cross-Linguistic Evaluation of a Gender-Ambiguous Dataset",
+    author = "Hackenbuchner, Jani{\c{c}}a  and
+      Daems, Joke  and
+      Gkovedarou, Eleni",
+    editor = "Fale{\'n}ska, Agnieszka  and
+      Basta, Christine  and
+      Costa-juss{\`a}, Marta  and
+      Sta{\'n}czak, Karolina  and
+      Nozza, Debora",
+    booktitle = "Proceedings of the 6th Workshop on Gender Bias in Natural Language Processing (GeBNLP)",
+    month = aug,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.gebnlp-1.27/",
+    pages = "302--319",
+    ISBN = "979-8-89176-277-0",
+}
+@inproceedings{mainardi-etal-2025-fine,
+    title = "Fine-Tuning vs Prompting Techniques for Gender-Fair Rewriting of Machine Translations",
+    author = "Mainardi, Paolo  and
+      Garcea, Federico  and
+      Barr{\'o}n-Cede{\~n}o, Alberto",
+    editor = "Fale{\'n}ska, Agnieszka  and
+      Basta, Christine  and
+      Costa-juss{\`a}, Marta  and
+      Sta{\'n}czak, Karolina  and
+      Nozza, Debora",
+    booktitle = "Proceedings of the 6th Workshop on Gender Bias in Natural Language Processing (GeBNLP)",
+    month = aug,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.gebnlp-1.28/",
+    pages = "320--337",
+    ISBN = "979-8-89176-277-0",
+}
+@inproceedings{bartl-etal-2025-adapting,
+    title = "Adapting Psycholinguistic Research for {LLM}s: Gender-inclusive Language in a Coreference Context",
+    author = "Bartl, Marion  and
+      Murphy, Thomas Brendan  and
+      Leavy, Susan",
+    editor = "Fale{\'n}ska, Agnieszka  and
+      Basta, Christine  and
+      Costa-juss{\`a}, Marta  and
+      Sta{\'n}czak, Karolina  and
+      Nozza, Debora",
+    booktitle = "Proceedings of the 6th Workshop on Gender Bias in Natural Language Processing (GeBNLP)",
+    month = aug,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.gebnlp-1.38/",
+    pages = "451--467",
+    ISBN = "979-8-89176-277-0",
 }
 
 LLMs
@@ -846,18 +962,6 @@ series = {CHI '24}
     doi = "10.18653/v1/2024.findings-emnlp.680",
     pages = "11612--11631",
 }
-@article{ovalle2024rootshapesfruitpersistence,
-      title={The Root Shapes the Fruit: On the Persistence of Gender-Exclusive Harms in Aligned Language Models}, 
-      author={Anaelia Ovalle and Krunoslav Lehman Pavasovic and Louis Martin and Luke Zettlemoyer and Eric Michael Smith and Kai-Wei Chang and Adina Williams and Levent Sagun},
-      year={2024},
-      month=dec,
-      journal = {Computing Research Repository},
-      volume = {arXiv:2411.03700},
-      eprint={2411.03700},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2411.03700}, 
-}
 @inproceedings{tint-2025-guardrails,
     title = "Guardrails, not Guidance: Understanding Responses to {LGBTQ}+ Language in Large Language Models",
     author = "Tint, Joshua",
@@ -930,7 +1034,7 @@ series = {CHI '24}
 @article{ostrow2025llmsreproducestereotypessexual,
       title={{LLM}s Reproduce Stereotypes of Sexual and Gender Minorities}, 
       author={Ruby Ostrow and Adam Lopez},
-      year={2025},x
+      year={2025},
       month=may,
       journal = {Computing Research Repository},
       volume = {arXiv:2501.05926},
@@ -954,6 +1058,22 @@ pages = {710–745},
 numpages = {36},
 keywords = {Natural Language Processing, Linguistics, Large Language Models, Sociolect, User Perception, User Behavior, Reliance, Anthropomorphization, African American English, Queer Slang},
 address = {Athens, Greece},
+series = {FAccT '25}
+}
+@inproceedings{10.1145/3715275.3732196,
+author = {Ovalle, Anaelia and Pavasovic, Krunoslav Lehman and Martin, Louis and Zettlemoyer, Luke and Smith, Eric Michael and Chang, Kai-Wei and Williams, Adina and Sagun, Levent},
+title = {The Root Shapes the Fruit: On the Persistence of Gender-Exclusive Harms in Aligned Language Models},
+year = {2025},
+month = jun,
+isbn = {9798400714825},
+publisher = {Association for Computing Machinery},
+address = {Athens, Greece},
+url = {https://doi.org/10.1145/3715275.3732196},
+doi = {10.1145/3715275.3732196},
+booktitle = {Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency},
+pages = {3094–3105},
+numpages = {12},
+location = {New York, NY, USA},
 series = {FAccT '25}
 }
 
@@ -1556,6 +1676,22 @@ Toxicity and Hate Speech
     doi = "10.18653/v1/2024.emnlp-main.132",
     pages = "2200--2218",
 }
+@inproceedings{chan-etal-2024-hate,
+    title = "``Is Hate Lost in Translation?'': Evaluation of Multilingual {LGBTQIA}+ Hate Speech Detection",
+    author = "Chan, Fai Leui  and
+      Nguyen, Duke  and
+      Joshi, Aditya",
+    editor = "Baldwin, Tim  and
+      Rodr{\'i}guez M{\'e}ndez, Sergio Jos{\'e}  and
+      Kuo, Nicholas",
+    booktitle = "Proceedings of the 22nd Annual Workshop of the Australasian Language Technology Association",
+    month = dec,
+    year = "2024",
+    address = "Canberra, Australia",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2024.alta-1.11/",
+    pages = "146--152",
+}
 @inproceedings{draetta-etal-2024-reclaim,
     title = "{R}e{CLAIM} Project: Exploring {I}talian Slurs Reappropriation with Large Language Models",
     author = "Draetta, Lia  and
@@ -1604,6 +1740,41 @@ Toxicity and Hate Speech
     year={2025},
     month=may,
     pages={51–79},
+}
+@inproceedings{10.1145/3715275.3732095,
+author = {Lameiro, Francesca and Dunagan, Lavinia and Card, Dallas and Gilbert, Eric and Haimson, Oliver},
+title = {{TIDE}s: A Transgender and Nonbinary Community-Labeled Dataset and Model for Transphobia Identification in Digital Environments},
+year = {2025},
+month = jun,
+isbn = {9798400714825},
+publisher = {Association for Computing Machinery},
+address = {Athens, Greece},
+url = {https://doi.org/10.1145/3715275.3732095},
+doi = {10.1145/3715275.3732095},
+booktitle = {Proceedings of the 2025 ACM Conference on Fairness, Accountability, and Transparency},
+pages = {1411–1423},
+numpages = {13},
+location = {New York, NY, USA},
+series = {FAccT '25}
+}
+@inproceedings{talas-hutchings-2025-beyond,
+    title = "Beyond the Binary: Analysing Transphobic Hate and Harassment Online",
+    author = "Talas, Anna  and
+      Hutchings, Alice",
+    editor = "Calabrese, Agostina  and
+      de Kock, Christine  and
+      Nozza, Debora  and
+      Plaza-del-Arco, Flor Miriam  and
+      Talat, Zeerak  and
+      Vargas, Francielle",
+    booktitle = "Proceedings of the The 9th Workshop on Online Abuse and Harms (WOAH)",
+    month = aug,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.woah-1.12/",
+    pages = "136--152",
+    ISBN = "979-8-89176-105-6",
 }
 
 Translation
@@ -1793,6 +1964,7 @@ Translation
 author = {Jourdan, Fanny and Chevalier, Yannick and Favre, C\'{e}cile},
 title = {FairTranslate: an {E}nglish-{F}rench Dataset for Gender Bias Evaluation in Machine Translation by Overcoming Gender Binarity},
 year = {2025},
+month = jun,
 isbn = {9798400714825},
 publisher = {Association for Computing Machinery},
 location = {New York, NY, USA},

--- a/refs.bib
+++ b/refs.bib
@@ -468,23 +468,6 @@ Gender Bias Including Nonbinary Genders
     url = "https://aclanthology.org/2020.gebnlp-1.8/",
     pages = "79--92",
 }
-@inproceedings{hansson-etal-2021-swedish,
-    title = "The {S}wedish {W}inogender Dataset",
-    author = "Hansson, Saga  and
-      Mavromatakis, Konstantinos  and
-      Adesam, Yvonne  and
-      Bouma, Gerlof  and
-      Dann{\'e}lls, Dana",
-    editor = "Dobnik, Simon  and
-      {\O}vrelid, Lilja",
-    booktitle = "Proceedings of the 23rd Nordic Conference on Computational Linguistics (NoDaLiDa)",
-    month = may # " 31--2 " # jun,
-    year = "2021",
-    address = "Reykjavik, Iceland (Online)",
-    publisher = {Link{\"o}ping University Electronic Press, Sweden},
-    url = "https://aclanthology.org/2021.nodalida-main.52/",
-    pages = "452--459",
-}
 @inproceedings{havens-etal-2022-uncertainty,
     title = "Uncertainty and Inclusivity in Gender Bias Annotation: An Annotation Taxonomy and Annotated Datasets of {B}ritish {E}nglish Text",
     author = "Havens, Lucy  and
@@ -615,19 +598,6 @@ Gender Bias Including Nonbinary Genders
     pages = "35--40",
     ISBN = "979-8-89176-244-2",
 }
-@article{doyen2025genrefrenchgenderneutralrewriting,
-      title={GeNRe: A French Gender-Neutral Rewriting System Using Collective Nouns},
-      author={Enzo Doyen and Amalia Todirascu},
-      year={2025},
-      mon=may,
-      journal = {Computing Research Repository},
-      volume = {arXiv:2505.23630},
-      eprint={2505.23630},
-      archivePrefix={arXiv},
-      primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2505.23630}, 
-      note={Forthcoming in ACL Findings 2025}
-}
 @inproceedings{10.1145/3715275.3732112,
 author = {Hafner, Franziska Sofia and Valdivia, Ana and Rocher, Luc},
 title = {Gender Trouble in Language Models: An Empirical Audit Guided by Gender Performativity Theory},
@@ -643,6 +613,23 @@ pages = {1677–1695},
 numpages = {19},
 location = {New York, NY, USA},
 series = {FAccT '25}
+}
+@inproceedings{doyen-todirascu-2025-genre,
+    title = "{G}e{NR}e: A {F}rench Gender-Neutral Rewriting System Using Collective Nouns",
+    author = "Doyen, Enzo  and
+      Todirascu, Amalia",
+    editor = "Che, Wanxiang  and
+      Nabende, Joyce  and
+      Shutova, Ekaterina  and
+      Pilehvar, Mohammad Taher",
+    booktitle = "Findings of the Association for Computational Linguistics: ACL 2025",
+    month = jul,
+    year = "2025",
+    address = "Vienna, Austria",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2025.findings-acl.411/",
+    pages = "7889--7909",
+    ISBN = "979-8-89176-256-5"
 }
 @inproceedings{rodriguez-etal-2025-colombian,
     title = "Colombian Waitresses y Jueces canadienses: Gender and Country Biases in Occupation Recommendations from {LLM}s",
@@ -2788,7 +2775,7 @@ IberLEF2023: HOMO-MEX
 
 IberLEF2023: HOPE
 @article{overview-hope2023,
-	author = {Salud María Jiménez-Zafra y Miguel Ángel Garcia-Cumbreras y Daniel García-Baena y José Antonio Garcia-Díaz y Bharathi Raja Chakravarthi y Rafael Valencia-García y Luis Alfonso Ureña-López},
+	author = {Salud María Jiménez-Zafra and Miguel Ángel Garcia-Cumbreras and Daniel García-Baena and José Antonio Garcia-Díaz and Bharathi Raja Chakravarthi and Rafael Valencia-García and Luis Alfonso Ureña-López},
 	title = {Overview of {HOPE} at {I}ber{LEF} 2023: Multilingual Hope Speech Detection},
 	journal = {Procesamiento del Lenguaje Natural},
 	volume = {71},
@@ -3017,7 +3004,7 @@ IberLEF2024: HOMO-MEX
 IberLEF2024: HOPE
 
 @article{overview-hope2024,
-	author = {Daniel García-Baena y Fazlourrahman Balouchzahi y Sabur Butt y Miguel Ángel García-Cumbreras y Atnafu Lambebo Tonja y José Antonio García-Díaz y Selen Bozkurt y Bharathi Raja Chakravarthi y Hector G. Ceballos y Rafael Valencia-García y Grigori Sidorov y L. Alfonso Ureña-López y Alexander Gelbukh y Salud María Jiménez-Zafra},
+	author = {Daniel García-Baena and Fazlourrahman Balouchzahi and Sabur Butt and Miguel Ángel García-Cumbreras and Atnafu Lambebo Tonja and José Antonio García-Díaz and Selen Bozkurt and Bharathi Raja Chakravarthi and Hector G. Ceballos and Rafael Valencia-García and Grigori Sidorov and L. Alfonso Ureña-López and Alexander Gelbukh and Salud María Jiménez-Zafra},
 	title = {Overview of HOPE at IberLEF 2024: Approaching Hope Speech Detection in Social Media from Two Perspectives, for Equality, Diversity and Inclusion and as Expectations},
 	journal = {Procesamiento del Lenguaje Natural},
 	volume = {73},


### PR DESCRIPTION
1.  Added papers from FAccT 2025 and ACL 2025.
2. Fixed small typos and inconsistencies in both the .bib file and the README.
3. While I was doing this change, the "Is Hate Lost in Translation?” paper was added, so I made sure to add it as well, also putting at the right place to maintain chronological order.